### PR TITLE
fix(generator): add NumNonZeroWorkloads and use it for avg_available_proportion_ppm

### DIFF
--- a/generator/monitor/monitor.go
+++ b/generator/monitor/monitor.go
@@ -129,8 +129,20 @@ func pprToStatus(ppr *podseidonv1a1.PodProtector) observer.MonitorWorkloads {
 		))
 	}
 
+	isNonZero := 0
+	if ppr.Spec.MinAvailable > 0 {
+		isNonZero = 1
+	}
+
+	isFullyAvailable := 0
+	if ppr.Status.Summary.AggregatedAvailable >= ppr.Spec.MinAvailable {
+		isFullyAvailable = 1
+	}
+
 	return observer.MonitorWorkloads{
 		NumWorkloads:                1,
+		NumNonZeroWorkloads:         isNonZero,
+		NumAvailableWorkloads:       isFullyAvailable,
 		MinAvailable:                int64(ppr.Spec.MinAvailable),
 		TotalReplicas:               int64(ppr.Status.Summary.Total),
 		AggregatedAvailableReplicas: int64(ppr.Status.Summary.AggregatedAvailable),

--- a/generator/monitor/monitor_test.go
+++ b/generator/monitor/monitor_test.go
@@ -81,9 +81,28 @@ func TestMonitor(t *testing.T) {
 					},
 				},
 			},
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "3",
+				},
+				Spec: podseidonv1a1.PodProtectorSpec{
+					MinAvailable: 0,
+				},
+				Status: podseidonv1a1.PodProtectorStatus{
+					Summary: podseidonv1a1.PodProtectorStatusSummary{
+						Total:               0,
+						AggregatedAvailable: 0,
+						EstimatedAvailable:  0,
+						MaxLatencyMillis:    0,
+					},
+				},
+			},
 		},
 		Expect: observer.MonitorWorkloads{
-			NumWorkloads:                2,
+			NumWorkloads:                3,
+			NumNonZeroWorkloads:         2,
+			NumAvailableWorkloads:       2,
 			MinAvailable:                10 + 100,
 			TotalReplicas:               13 + 200,
 			AggregatedAvailableReplicas: 8 + 150,
@@ -101,7 +120,9 @@ func TestMonitor(t *testing.T) {
 		},
 		Delete: []types.NamespacedName{{Namespace: "default", Name: "1"}},
 		Expect: observer.MonitorWorkloads{
-			NumWorkloads:                1,
+			NumWorkloads:                2,
+			NumNonZeroWorkloads:         1,
+			NumAvailableWorkloads:       1,
 			MinAvailable:                200,
 			TotalReplicas:               200,
 			AggregatedAvailableReplicas: 150,

--- a/generator/observer/metrics.go
+++ b/generator/observer/metrics.go
@@ -83,6 +83,18 @@ func ProvideMetrics() component.Declared[Observer] {
 					func(status MonitorWorkloads) int { return status.NumWorkloads },
 				),
 				metrics.NewField(
+					"num_non_zero_workloads",
+					"Number of workload objects managed by this generator with non-zero minAvailable",
+					metrics.IntGauge(),
+					func(status MonitorWorkloads) int { return status.NumNonZeroWorkloads },
+				),
+				metrics.NewField(
+					"num_available_workloads",
+					"Number of workload objects managed by this generator with minAvailable satisfied",
+					metrics.IntGauge(),
+					func(status MonitorWorkloads) int { return status.NumAvailableWorkloads },
+				),
+				metrics.NewField(
 					"min_available",
 					"Sum of minAvailable over workloads managed by this generator",
 					metrics.Int64Gauge(),
@@ -117,7 +129,7 @@ func ProvideMetrics() component.Declared[Observer] {
 					"Unweighted average of service availability for every PodProtector (0 to 1).",
 					metrics.FloatGauge(),
 					func(status MonitorWorkloads) float64 {
-						return float64(status.SumAvailableProportionPpm) / 1e6 / float64(status.NumWorkloads)
+						return float64(status.SumAvailableProportionPpm) / 1e6 / float64(status.NumNonZeroWorkloads)
 					},
 				),
 				metrics.NewField(

--- a/generator/observer/observer.go
+++ b/generator/observer/observer.go
@@ -93,6 +93,12 @@ type MonitorWorkloads struct {
 	// Number of workload objects managed by this generator.
 	NumWorkloads int
 
+	// Number of workload objects managed by this generator with non-zero minAvailable.
+	NumNonZeroWorkloads int
+
+	// Number of workload objects managed by this generator with minAvailable satisfied.
+	NumAvailableWorkloads int
+
 	// Sum of minAvailable over workloads managed by this generator.
 	MinAvailable int64
 
@@ -106,7 +112,8 @@ type MonitorWorkloads struct {
 	EstimatedAvailableReplicas int64
 
 	// Sum of the proportion of aggregated available replicas, saturated at 1, rounded to nearest ppm (parts-per-million).
-	// When divided by NumWorkloads, this is the unweighted average of service availability for every PodProtector.
+	// Workloads with zero minAvailable do not contribute to this sum.
+	// When divided by NumNonZeroWorkloads, this is the unweighted average of service availability for every PodProtector.
 	SumAvailableProportionPpm int64
 
 	// Sum of the .status.summary.maxLatencyMillis field over workloads managed by this generator.
@@ -115,6 +122,8 @@ type MonitorWorkloads struct {
 
 func (dest *MonitorWorkloads) Add(delta MonitorWorkloads) {
 	dest.NumWorkloads += delta.NumWorkloads
+	dest.NumNonZeroWorkloads += delta.NumNonZeroWorkloads
+	dest.NumAvailableWorkloads += delta.NumAvailableWorkloads
 	dest.MinAvailable += delta.MinAvailable
 	dest.TotalReplicas += delta.TotalReplicas
 	dest.AggregatedAvailableReplicas += delta.AggregatedAvailableReplicas
@@ -125,6 +134,8 @@ func (dest *MonitorWorkloads) Add(delta MonitorWorkloads) {
 
 func (dest *MonitorWorkloads) Subtract(delta MonitorWorkloads) {
 	dest.NumWorkloads -= delta.NumWorkloads
+	dest.NumNonZeroWorkloads -= delta.NumNonZeroWorkloads
+	dest.NumAvailableWorkloads -= delta.NumAvailableWorkloads
 	dest.MinAvailable -= delta.MinAvailable
 	dest.TotalReplicas -= delta.TotalReplicas
 	dest.AggregatedAvailableReplicas -= delta.AggregatedAvailableReplicas


### PR DESCRIPTION
Zero entries from zero-replica workloads would pull down the mean availability fulfillment ratio