### PR TITLE
fix(aggregator): randomize aggregation rate

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -166,7 +166,7 @@ linters-settings:
   mnd:
     ignored-numbers: ['0', '1', '2', '3', '4', '8', '16', '32', '64', '0.', '1.', '100.']
     ignored-functions:
-      - 'fs\.(Duration|Int[0-9]*)'
+      - 'fs\.(Duration|Int[0-9]*|Float32|Float64)'
       - 'utilflag\.(Uint[0-9]*|Int[0-9]*)'
       - 'metrics\.ExponentialIntHistogram'
   revive:

--- a/tests/util/expect.go
+++ b/tests/util/expect.go
@@ -106,6 +106,16 @@ func DoUpdate[T runtime.Object](
 	gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 }
 
+func getPprCell(ppr *podseidonv1a1.PodProtector, worker WorkerIndex) optional.Optional[podseidonv1a1.PodProtectorCellStatus] {
+	for _, cell := range ppr.Status.Cells {
+		if cell.CellId == worker.String() {
+			return optional.Some(cell)
+		}
+	}
+
+	return optional.None[podseidonv1a1.PodProtectorCellStatus]()
+}
+
 func MatchPprStatus(totalReplicas int32, aggregatedAvailable int32, estimatedAvailable int32,
 	workerTotalReplicas [2]int32, workerAvailableReplicas [2]int32,
 ) gomega.OmegaMatcher {
@@ -124,29 +134,25 @@ func MatchPprStatus(totalReplicas int32, aggregatedAvailable int32, estimatedAva
 		),
 		gomega.WithTransform(
 			func(ppr *podseidonv1a1.PodProtector) int32 {
-				return optional.GetSlice(ppr.Status.Cells, 0).GetOrZero().Aggregation.TotalReplicas
+				return getPprCell(ppr, 0).GetOrZero().Aggregation.TotalReplicas
 			},
 			gomega.Equal(workerTotalReplicas[0]),
 		),
 		gomega.WithTransform(
 			func(ppr *podseidonv1a1.PodProtector) int32 {
-				return optional.GetSlice(ppr.Status.Cells, 0).
-					GetOrZero().
-					Aggregation.AvailableReplicas
+				return getPprCell(ppr, 0).GetOrZero().Aggregation.AvailableReplicas
 			},
 			gomega.Equal(workerAvailableReplicas[0]),
 		),
 		gomega.WithTransform(
 			func(ppr *podseidonv1a1.PodProtector) int32 {
-				return optional.GetSlice(ppr.Status.Cells, 1).GetOrZero().Aggregation.TotalReplicas
+				return getPprCell(ppr, 1).GetOrZero().Aggregation.TotalReplicas
 			},
 			gomega.Equal(workerTotalReplicas[1]),
 		),
 		gomega.WithTransform(
 			func(ppr *podseidonv1a1.PodProtector) int32 {
-				return optional.GetSlice(ppr.Status.Cells, 1).
-					GetOrZero().
-					Aggregation.AvailableReplicas
+				return getPprCell(ppr, 1).GetOrZero().Aggregation.AvailableReplicas
 			},
 			gomega.Equal(workerAvailableReplicas[1]),
 		),

--- a/tests/util/setup.go
+++ b/tests/util/setup.go
@@ -416,13 +416,17 @@ type (
 	PodIndex    int32
 )
 
+func (index WorkerIndex) String() string {
+	return fmt.Sprintf("worker-%d", index+1)
+}
+
 type PodId struct {
 	Worker WorkerIndex
 	Pod    PodIndex
 }
 
 func (id PodId) PodName() string {
-	return fmt.Sprintf("worker-%d-pod-%d", int32(id.Worker)+1, id.Pod)
+	return fmt.Sprintf("%s-pod-%d", id.Worker, id.Pod)
 }
 
 type PodCounts [2]PodIndex

--- a/util/optional/optional.go
+++ b/util/optional/optional.go
@@ -169,7 +169,7 @@ func FromPtr[T any](ptr *T) Optional[T] {
 
 // Returns `Some(slice[index])` if it exists, None otherwise.
 func GetSlice[T any](slice []T, index int) Optional[T] {
-	if index < len(slice) {
+	if index >= 0 && index < len(slice) {
 		return Some(slice[index])
 	}
 


### PR DESCRIPTION
This reduces update conflicts caused by concurrent scaling operations from multiple clusters, e.g.
<img width="723" alt="image" src="https://github.com/user-attachments/assets/b1ec8e54-b9d5-4e2b-a790-80d4552e36a9" />
