### PR TITLE
fix: Earthfile and helm chart appVersion and image

### DIFF
--- a/chart/templates/_deployment.yaml
+++ b/chart/templates/_deployment.yaml
@@ -4,8 +4,8 @@
 Main entrypoint for a component.
 Additional parameters:
   .deployedCluster: the cluster to deploy pods of this component in, either "core" or "worker"
-  .binary: path to main process binary in the image
   .args: args passed to the container process (should include boilerplate args)
+  .binary: path to main process binary in the image, nil to use default image entrypoint
   .env: env vars set for the container process
   .volumes: dictionary of required volumes in BoilerplateVolumes format:
     key: volume name
@@ -78,10 +78,13 @@ Additional parameters:
 name: main
 securityContext: {{toJson .generic.containerSecurityContext}}
 resources: {{toJson .generic.resources}}
-{{- $image := get .main.Values.common.image .component | default dict | deepCopy | merge (deepCopy .main.Values.common.image)}}
+{{- $image := deepCopy .main.Values.common.image | merge (get .main.Values.common.image .component | default dict) }}
 image: {{printf "%s:%s" $image.repository ($image.tag | default .main.Chart.AppVersion) | toJson}}
 imagePullPolicy: {{toJson $image.pullPolicy}}
-command: {{prepend (include "podseidon.boilerplate.args.yaml-array" . | fromYamlArray) .binary | toJson}}
+{{- if .binary}}
+command: [{{toJson .binary}}]
+{{- end}}
+args: {{include "podseidon.boilerplate.args.yaml-array" . | fromYamlArray | toJson}}
 env: [
   {{- range $k, $v := .env}}
   {

--- a/chart/templates/aggregator.yaml
+++ b/chart/templates/aggregator.yaml
@@ -7,7 +7,6 @@
 }}
 {{- dict
     "deployedCluster" "core"
-    "binary" "/usr/local/bin/podseidon-aggregator"
     "args" (include "podseidon.aggregator.args.yaml" $ctx | fromYaml)
     "env" (dict)
     "volumes" (include "podseidon.aggregator.volumes.yaml" $ctx | fromYaml)

--- a/chart/templates/generator.yaml
+++ b/chart/templates/generator.yaml
@@ -7,7 +7,6 @@
 }}
 {{- dict
     "deployedCluster" "core"
-    "binary" "/usr/local/bin/podseidon-generator"
     "args" (include "podseidon.generator.args.yaml" $ctx | fromYaml)
     "env" (dict)
     "volumes" (include "podseidon.generator.volumes.yaml" $ctx | fromYaml)

--- a/chart/templates/webhook.yaml
+++ b/chart/templates/webhook.yaml
@@ -7,7 +7,6 @@
 }}
 {{- dict
     "deployedCluster" "core"
-    "binary" "/usr/local/bin/podseidon-webhook"
     "args" (include "podseidon.webhook.args.yaml" $ctx | fromYaml)
     "env" (dict)
     "volumes" (include "podseidon.webhook.volumes.yaml" $ctx | fromYaml)


### PR DESCRIPTION
This PR aims to fix issues in the helm chart and Earthfile. I'm not sure if AppVersion was intentionally set to `0.0.0` but I updated it to the latest release `0.2.1`. The image was always rendered the `common.image.repository` for all components and I just fixed the order in the deepMerge operation.

Also I realized that the container args expects that binaries inside container has named within component name but I realized that the `build-image` part in the `Earthfile` was converting them to `/usr/local/bin/app` which I believe a mistake.