### PR TITLE
fix(chart): do not override image entrypoint from chart

### DIFF
--- a/chart/templates/_deployment.yaml
+++ b/chart/templates/_deployment.yaml
@@ -81,7 +81,10 @@ resources: {{toJson .generic.resources}}
 {{- $image := get .main.Values.common.image .component | default dict | deepCopy | merge (deepCopy .main.Values.common.image)}}
 image: {{printf "%s:%s" $image.repository ($image.tag | default .main.Chart.AppVersion) | toJson}}
 imagePullPolicy: {{toJson $image.pullPolicy}}
-command: {{prepend (include "podseidon.boilerplate.args.yaml-array" . | fromYamlArray) .binary | toJson}}
+{{- if .binary}}
+command: [{{toJson .binary}}]
+{{- end}}
+args: {{(include "podseidon.boilerplate.args.yaml-array" . | fromYamlArray | toJson)}}
 env: [
   {{- range $k, $v := .env}}
   {

--- a/chart/templates/aggregator.yaml
+++ b/chart/templates/aggregator.yaml
@@ -7,7 +7,6 @@
 }}
 {{- dict
     "deployedCluster" "core"
-    "binary" "/usr/local/bin/podseidon-aggregator"
     "args" (include "podseidon.aggregator.args.yaml" $ctx | fromYaml)
     "env" (dict)
     "volumes" (include "podseidon.aggregator.volumes.yaml" $ctx | fromYaml)

--- a/chart/templates/generator.yaml
+++ b/chart/templates/generator.yaml
@@ -7,7 +7,6 @@
 }}
 {{- dict
     "deployedCluster" "core"
-    "binary" "/usr/local/bin/podseidon-generator"
     "args" (include "podseidon.generator.args.yaml" $ctx | fromYaml)
     "env" (dict)
     "volumes" (include "podseidon.generator.volumes.yaml" $ctx | fromYaml)

--- a/chart/templates/webhook.yaml
+++ b/chart/templates/webhook.yaml
@@ -7,7 +7,6 @@
 }}
 {{- dict
     "deployedCluster" "core"
-    "binary" "/usr/local/bin/podseidon-webhook"
     "args" (include "podseidon.webhook.args.yaml" $ctx | fromYaml)
     "env" (dict)
     "volumes" (include "podseidon.webhook.volumes.yaml" $ctx | fromYaml)


### PR DESCRIPTION
As mentioned in #165, the default entrypoint should be `/usr/local/bin/app`. The template preserves the ability to override the command if necessary, but it should otherwise be left to discretion by the docker image.